### PR TITLE
Provide --save_detection_json support for videos

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -137,6 +137,7 @@ color_cache = defaultdict(lambda: {})
 
 frame_id = 0
 import multiprocessing
+import threading
 
 def prep_display(dets_out, img, h, w, undo_transform=True, class_color=False, mask_alpha=0.45, fps_str='', json_save_path=""):
     """
@@ -144,12 +145,12 @@ def prep_display(dets_out, img, h, w, undo_transform=True, class_color=False, ma
     """
 
     global frame_id
-    # curr_lock = multiprocessing.Lock()
+    curr_lock = threading.Lock()
 
-    # curr_lock.acquire()
+    curr_lock.acquire(True, -1)
     print(f"Thread ID: {threading.current_thread().name} :: Frame: {frame_id}")
     frame_id += 1
-    # curr_lock.release()
+    curr_lock.release()
 
     if undo_transform:
         img_numpy = undo_image_transformation(img, w, h)

--- a/eval.py
+++ b/eval.py
@@ -665,7 +665,7 @@ def evalimages(net:Yolact, input_folder:str, output_folder:str):
     print('Done.')
 
 from multiprocessing.pool import ThreadPool
-import threading
+# import threading
 from queue import Queue
 
 class CustomDataParallel(torch.nn.DataParallel):

--- a/eval.py
+++ b/eval.py
@@ -262,7 +262,7 @@ def prep_display(dets_out, img, h, w, undo_transform=True, class_color=False, ma
             if ':' in args.video:
                 outpath = args.video.split(':')[1] + ".json"
                 with open(outpath, "a") as outfd:
-                    outfd.write(json.dumps(detection_dict))
+                    outfd.write(json.dumps(detection_dict) + "\n")
             else:
                 cam_id = args.video
 

--- a/eval.py
+++ b/eval.py
@@ -139,6 +139,9 @@ def prep_display(dets_out, img, h, w, undo_transform=True, class_color=False, ma
     """
     Note: If undo_transform=False then im_h and im_w are allowed to be None.
     """
+
+    print(f"Thread ID: {threading.current_thread().name}")
+
     if undo_transform:
         img_numpy = undo_image_transformation(img, w, h)
         img_gpu = torch.Tensor(img_numpy).cuda()
@@ -745,7 +748,6 @@ def evalvideo(net:Yolact, path:str, out_path:str=None):
     # All this timing code to make sure that 
     def play_video():
         try:
-            print(f"Thread ID: {threading.current_thread()}")
             nonlocal frame_buffer, running, video_fps, is_webcam, num_frames, frames_displayed, vid_done
 
             video_frame_times = MovingAverage(100)

--- a/eval.py
+++ b/eval.py
@@ -839,7 +839,6 @@ def evalvideo(net:Yolact, path:str, out_path:str=None):
     # For each frame the sequence of functions it needs to go through to be processed (in reversed order)
     sequence = [prep_frame, eval_network, transform_frame]
     pool = ThreadPool(processes=len(sequence) + args.video_multiframe + 2)
-    print(f"Starting Thread Pool with {len(sequence) + args.video_multiframe + 2} threads")
     pool.apply_async(play_video)
     active_frames = [{'value': extract_frame(first_batch, i), 'idx': 0} for i in range(len(first_batch[0]))]
 

--- a/eval.py
+++ b/eval.py
@@ -265,6 +265,9 @@ def prep_display(dets_out, img, h, w, undo_transform=True, class_color=False, ma
                     outfd.write(json.dumps(detection_dict) + "\n")
             else:
                 cam_id = args.video
+                outpath = "yolact_cam_" + cam_id + ".json"
+                with open(outpath, "a") as outfd:
+                    outfd.write(json.dumps(detection_dict) + "\n")
 
             frame_id += 1
 
@@ -933,6 +936,11 @@ def evaluate(net:Yolact, dataset, train_mode=False):
                     pass
             evalvideo(net, inp, out)
         else:
+            if args.save_detection_json:
+                try:
+                    os.remove("yolact_cam_" + args.video + ".json")
+                except FileNotFoundError:
+                    pass
             evalvideo(net, args.video)
         return
 

--- a/eval.py
+++ b/eval.py
@@ -926,6 +926,11 @@ def evaluate(net:Yolact, dataset, train_mode=False):
     elif args.video is not None:
         if ':' in args.video:
             inp, out = args.video.split(':')
+            if args.save_detection_json:
+                try:
+                    os.remove(out + ".json")
+                except FileNotFoundError:
+                    pass
             evalvideo(net, inp, out)
         else:
             evalvideo(net, args.video)

--- a/eval.py
+++ b/eval.py
@@ -135,12 +135,21 @@ coco_cats = {} # Call prep_coco_cats to fill this
 coco_cats_inv = {}
 color_cache = defaultdict(lambda: {})
 
+frame_id = 0
+import multiprocessing
+
 def prep_display(dets_out, img, h, w, undo_transform=True, class_color=False, mask_alpha=0.45, fps_str='', json_save_path=""):
     """
     Note: If undo_transform=False then im_h and im_w are allowed to be None.
     """
 
-    print(f"Thread ID: {threading.current_thread().name}")
+    global frame_id
+    curr_lock = multiprocessing.Lock()
+
+    curr_lock.acquire()
+    print(f"Thread ID: {threading.current_thread().name} :: Frame: {frame_id}")
+    frame_id += 1
+    curr_lock.release()
 
     if undo_transform:
         img_numpy = undo_image_transformation(img, w, h)

--- a/eval.py
+++ b/eval.py
@@ -652,7 +652,7 @@ def evalimages(net:Yolact, input_folder:str, output_folder:str):
     print('Done.')
 
 from multiprocessing.pool import ThreadPool
-import multiprocessing
+import threading
 from queue import Queue
 
 class CustomDataParallel(torch.nn.DataParallel):
@@ -744,8 +744,8 @@ def evalvideo(net:Yolact, path:str, out_path:str=None):
 
     # All this timing code to make sure that 
     def play_video():
-        print(f"PID: {multiprocessing.current_process().pid}")
         try:
+            print(f"Thread ID: {threading.current_thread()}")
             nonlocal frame_buffer, running, video_fps, is_webcam, num_frames, frames_displayed, vid_done
 
             video_frame_times = MovingAverage(100)
@@ -827,6 +827,7 @@ def evalvideo(net:Yolact, path:str, out_path:str=None):
     # For each frame the sequence of functions it needs to go through to be processed (in reversed order)
     sequence = [prep_frame, eval_network, transform_frame]
     pool = ThreadPool(processes=len(sequence) + args.video_multiframe + 2)
+    print(f"Starting Thread Pool with {len(sequence) + args.video_multiframe + 2} threads")
     pool.apply_async(play_video)
     active_frames = [{'value': extract_frame(first_batch, i), 'idx': 0} for i in range(len(first_batch[0]))]
 

--- a/eval.py
+++ b/eval.py
@@ -144,12 +144,12 @@ def prep_display(dets_out, img, h, w, undo_transform=True, class_color=False, ma
     """
 
     global frame_id
-    curr_lock = multiprocessing.Lock()
+    # curr_lock = multiprocessing.Lock()
 
-    curr_lock.acquire()
+    # curr_lock.acquire()
     print(f"Thread ID: {threading.current_thread().name} :: Frame: {frame_id}")
     frame_id += 1
-    curr_lock.release()
+    # curr_lock.release()
 
     if undo_transform:
         img_numpy = undo_image_transformation(img, w, h)

--- a/eval.py
+++ b/eval.py
@@ -143,7 +143,7 @@ def prep_display(dets_out, img, h, w, undo_transform=True, class_color=False, ma
     """
 
     global frame_id
-    print(f"Thread ID: {threading.current_thread().name} :: Frame: {frame_id}")
+    # print(f"Thread ID: {threading.current_thread().name} :: Frame: {frame_id}")
 
     if undo_transform:
         img_numpy = undo_image_transformation(img, w, h)

--- a/eval.py
+++ b/eval.py
@@ -169,11 +169,6 @@ def prep_display(dets_out, img, h, w, undo_transform=True, class_color=False, ma
             num_dets_to_consider = j
             break
 
-    # print(f"Classes:\t{classes.tolist()}")
-    # print(f"Class Names:\t{[cfg.dataset.class_names[classes[j]] for j in range(num_dets_to_consider)]}")
-    # print(f"Scores:\t{scores.tolist()}")
-    # print(f"Boxes:\t{boxes.tolist()}")
-
     # Quick and dirty lambda for selecting the color for a particular index
     # Also keeps track of a per-gpu color cache for maximum speed
     def get_color(j, on_gpu=None):
@@ -255,6 +250,13 @@ def prep_display(dets_out, img, h, w, undo_transform=True, class_color=False, ma
         if args.image is not None or args.images is not None:
             with open(json_save_path, "w") as outfd:
                 json.dump(detection_dict, outfd, indent=4)
+
+        elif args.video is not None:
+            pass
+            # if ':' in args.video:
+            #     outpath = args.video.split(':')[1]
+            # else:
+            #     cam_id = args.video
 
 
 
@@ -650,6 +652,7 @@ def evalimages(net:Yolact, input_folder:str, output_folder:str):
     print('Done.')
 
 from multiprocessing.pool import ThreadPool
+import multiprocessing
 from queue import Queue
 
 class CustomDataParallel(torch.nn.DataParallel):
@@ -741,6 +744,7 @@ def evalvideo(net:Yolact, path:str, out_path:str=None):
 
     # All this timing code to make sure that 
     def play_video():
+        print(f"PID: {multiprocessing.current_process().pid}")
         try:
             nonlocal frame_buffer, running, video_fps, is_webcam, num_frames, frames_displayed, vid_done
 


### PR DESCRIPTION
### **ONLY WORKS WITH `--video_multiframe=1`**  

`--save_detection_json` will output a file with a json per line for each frame in the video with an additional "frame_id" key. The output file location will be `{VIDEO_OUTPUT}.json`  

Also works with live video streams. The output file location will be `./yolact_cam_{CAM_ID}.json`. Use with `tail -n 1` to get most recent frame. Other programs using this file can remove it periodically to delete old and unwanted frames to free disk space as the next frame that is processed will recreate this file.